### PR TITLE
Fix role name to remove "hooks"

### DIFF
--- a/playbooks/ionos.yml
+++ b/playbooks/ionos.yml
@@ -2,15 +2,14 @@
 - hosts: "{{ frontend_group | d('frontend') }}"
   roles:
     - role: ionosctl
-    - role: one-driver-hooks
+    - role: one-driver
       vars:
         get_dc_uuids: true
         render_driver_hooks: true
-          
+
 - hosts: "{{ node_group | d('node') }}"
   roles:
     - role: ionosctl
-    - role: one-driver-hooks
+    - role: one-driver
       vars:
         distribute_uuids: true
-

--- a/roles/one-driver/README.md
+++ b/roles/one-driver/README.md
@@ -1,0 +1,5 @@
+# IONOS role for OpenNebula driver
+
+This Ansible role contains the IONOS-specific driver that is installed to the IONOS deployment.
+
+More information about driver development can be found in the OpenNebula documentation for version 7.0 [here](https://docs.opennebula.io/7.0/product/integration_references/infrastructure_drivers_development/). For OpenNebula version 6.10, refer to the documentation [here](https://docs.opennebula.io/6.10/integration_and_development/infrastructure_drivers_development/index.html).


### PR DESCRIPTION
This pull request updates the configuration and documentation for the IONOS-specific OpenNebula driver. The key changes involve replacing the `one-driver-hooks` role with the `one-driver` role in the playbook and adding documentation for the new role.

### Updates to playbooks:

* Replaced the `one-driver-hooks` role with the `one-driver` role in the `playbooks/ionos.yml` file for both `frontend` and `node` hosts. This aligns the playbook with the updated driver implementation.

### Documentation updates:

* Added a new `README.md` file for the `one-driver` role, providing an overview of its purpose and links to relevant OpenNebula driver development documentation for versions 7.0 and 6.10.


Closes #4 